### PR TITLE
Use PropTypes from prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "node-sass": "^3.4.2",
     "opn": "^4.0.0",
     "postcss-loader": "^0.8.0",
+    "prop-types": "^15.5.10",
     "react-dom": "^0.14 || ^15.0.0",
     "react-router": "^2.0.0",
     "react-transform-hmr": "^1.0.1",

--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -1,14 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
+import PropTypes from 'prop-types';
 
 class Tooltip extends React.Component {
   static propTypes = {
-    container: React.PropTypes.any,
-    children: React.PropTypes.node.isRequired,
-    title: React.PropTypes.string.isRequired,
-    position: React.PropTypes.oneOf(['left', 'top', 'right', 'bottom']),
-    fixed: React.PropTypes.bool,
-    space: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.number])
+    container: PropTypes.any,
+    children: PropTypes.node.isRequired,
+    title: PropTypes.string.isRequired,
+    position: PropTypes.oneOf(['left', 'top', 'right', 'bottom']),
+    fixed: PropTypes.bool,
+    space: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
   };
 
   static defaultProps = {


### PR DESCRIPTION
… as accessing them from the main React object is being deprecated in React 15.5