### PR TITLE
Trigger a handleMouseMove() call after title changes to recalculate position

### DIFF
--- a/src/Tooltip.js
+++ b/src/Tooltip.js
@@ -40,9 +40,12 @@ class Tooltip extends React.Component {
     this.componentEl.addEventListener('mouseleave', this.handleMouseOut);
   };
 
-  componentDidUpdate = () => {
+  componentDidUpdate = (prevProps) => {
     this.tooltipEl.className = 'tooltip ' + this.props.position;
     this.tooltipEl.childNodes[1].textContent = this.props.title;
+    if (prevProps.title !== this.props.title) {
+      this.handleMouseMove();
+    }
   };
 
 


### PR DESCRIPTION
Currently, if the tooltip is fixed and the title changes dynamically, it can appear off-center if the title change also changes the width of the tooltip. For example:

![tooltip-title-change-wrong](https://user-images.githubusercontent.com/7499938/35581949-e7da203e-05c7-11e8-84de-9de1b886d782.gif)

This PR corrects this behaviour by triggering a recalculation of the tooltips positions if the title changes. Now, it behaves like this:

![tooltip-title-change-correct](https://user-images.githubusercontent.com/7499938/35581995-041d4d2a-05c8-11e8-932e-2c75001adae8.gif)
